### PR TITLE
Check that fingerings don't already exist before submitting

### DIFF
--- a/app/views/fingerings/index.html.erb
+++ b/app/views/fingerings/index.html.erb
@@ -7,6 +7,10 @@
 <% end %>
 
 <% content_for :content do %>
+	<% if notice != nil %>
+		<p><font color="red"><%= notice %></font></p>
+	<% end %>
+	
 	<table>
 		<tr>
 			<th>ID</th>

--- a/app/views/fingerings/index.mobile.erb
+++ b/app/views/fingerings/index.mobile.erb
@@ -3,6 +3,10 @@
 <% end %>
 
 <% content_for :content do %>
+	<% if notice != nil %>
+		<p><font color="red"><%= notice %></font></p>
+	<% end %>
+	
 	<table>
 		<tr>
 			<th>ID</th>


### PR DESCRIPTION
We now check to see if a fingering exists when a user/admin enters one. If it doesn't exist, the fingering is created/submitted for approval. If the fingering already exists, then we don't create a duplicate but post one of two notices:

1) The fingering exists and is currently pending approval
2) The fingering exists and can be seen at ID #<x>
