### PR TITLE
Use URL encoding to fix broken Team Webpage link

### DIFF
--- a/readme.rdoc
+++ b/readme.rdoc
@@ -7,7 +7,7 @@ for a note or series of notes. Bassoon Fingering Finder is currently in developm
 Questions or suggestions? Send us an email at bassoonfingeringfinder@gmail.com!
 
 == Links
-Team Webpage: link:http://mindworks.shoutwiki.com/wiki/Bassoon_Fingering_Finder_(BFF)
+Team Webpage: link:http://mindworks.shoutwiki.com/wiki/Bassoon_Fingering_Finder_%28BFF%29
 
 == Contact Address
 bassoonfingeringfinder@gmail.com


### PR DESCRIPTION
There is a bug in RDoc where it excludes the final closing parenthesis in a link. I encoded the parentheses characters so that the link is valid again.

Before:

![screen shot 2015-10-23 at 5 28 32 pm](https://cloud.githubusercontent.com/assets/1066522/10705411/beda9f6a-79ab-11e5-92f3-6152539934d7.png)

After:

![screen shot 2015-10-23 at 5 29 01 pm](https://cloud.githubusercontent.com/assets/1066522/10705415/c6f360ce-79ab-11e5-8c9f-44a5eb39b8df.png)
